### PR TITLE
Optional `depth` config parameter

### DIFF
--- a/.changeset/gentle-baboons-sell.md
+++ b/.changeset/gentle-baboons-sell.md
@@ -1,0 +1,5 @@
+---
+"figma-export-assets": minor
+---
+
+Optional `depth` parameter for `setAssets()`

--- a/README.md
+++ b/README.md
@@ -143,39 +143,40 @@ This can be overriden in every `createAssets` call.
 ```typescript
 {
     /**
-     * - Personal access token for the Figma API.
+     * Personal access token for the Figma API.
      */
     figmaPersonalToken: string;
     /**
-     * - The ID of the Figma file to export assets from.
+     * The ID of the Figma file to export assets from.
      */
     fileId: string;
     /**
-     * - The name of the page to export assets from.
+     * The name of the page to export assets from.
      */
     page: string;
     /**
-     * - The path to save the exported assets.
+     * The path to save the exported assets.
      */
     assetsPath: string;
     /**
-     * - The format of the exported assets.
+     * The format of the exported assets.
      */
     format?: string;
     /**
-     * - The scale at which to export assets.
+     * The scale at which to export assets.
      */
     scale?: number;
     /**
-     * - Whether to export variants of the assets.
+     * Whether to export variants of the assets.
      */
     exportVariants?: boolean;
     /**
-     * - The name of the frame to export assets from.
+     * The name of the frame to export assets from.
      */
     frame?: string;
     /**
-     * - Maximum number of nested levels to traverse in the Figma file.
+     * Maximum number of nested levels to traverse in the Figma file.
+     * See https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint for details.
      */
     depth?: number;
     /**

--- a/README.md
+++ b/README.md
@@ -176,19 +176,20 @@ This can be overriden in every `createAssets` call.
     frame?: string;
     /**
      * Maximum number of nested levels to traverse in the Figma file.
-     * See https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint for details.
+     * See https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint
+     * for details.
      */
     depth?: number;
     /**
-     * - The number of assets to export in each batch.
+     * The number of assets to export in each batch.
      */
     batchSize?: number;
     /**
-     * - The maximum number of concurrent requests.
+     * The maximum number of concurrent requests.
      */
     concurrencyLimit?: number;
     /**
-     * - Whether to skip existing files.
+     * Whether to skip existing files.
      */
     skipExistingFiles?: boolean;
 };
@@ -201,19 +202,19 @@ This can be overriden in every `createAssets` call to optimize paths or names.
 ```ts
 {
     /**
-     * - The ID of the asset.
+     * The ID of the asset.
      */
     id: string;
     /**
-     * - The name of the asset.
+     * The name of the asset.
      */
     name: string;
     /**
-     * - The URL of the asset image.
+     * The URL of the asset image.
      */
     url?: string;
     /**
-     * - The path to save the asset.
+     * The path to save the asset.
      */
     assetsPath?: string;
 }

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ This can be overriden in every `createAssets` call.
      */
     frame?: string;
     /**
+     * - Maximum number of nested levels to traverse in the Figma file.
+     */
+    depth?: number;
+    /**
      * - The number of assets to export in each batch.
      */
     batchSize?: number;

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ import pLimit from "p-limit";
  * @property {boolean} [exportVariants=true] - Whether to export variants of the assets.
  * @property {string} [frame] - The name of the frame to export assets from.
  * @property {number} [depth] - Maximum number of nested levels to traverse in the Figma file.
+ *   See [Figma API docs](https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint) 
+ *   for more details.
  * @property {number} [batchSize=100] - The number of assets to export in each batch.
  * @property {number} [concurrencyLimit=5] - The maximum number of concurrent requests.
  * @property {boolean} [skipExistingFiles=false] - Whether to skip existing files.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 import fs from "node:fs";
-import path from "node:path";
-import { mkdirp } from "mkdirp";
-import { Readable } from "node:stream";
-import pLimit from "p-limit";
 import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
 import { join } from "node:path";
+import { Readable } from "node:stream";
+import { mkdirp } from "mkdirp";
+import pLimit from "p-limit";
 
 /**
  * @typedef {Object} Config
@@ -16,6 +16,7 @@ import { join } from "node:path";
  * @property {number} [scale=1] - The scale at which to export assets.
  * @property {boolean} [exportVariants=true] - Whether to export variants of the assets.
  * @property {string} [frame] - The name of the frame to export assets from.
+ * @property {number} [depth] - Maximum number of nested levels to traverse in the Figma file.
  * @property {number} [batchSize=100] - The number of assets to export in each batch.
  * @property {number} [concurrencyLimit=5] - The maximum number of concurrent requests.
  * @property {boolean} [skipExistingFiles=false] - Whether to skip existing files.
@@ -57,7 +58,7 @@ export default class FigmaExporter {
    */
   constructor(config) {
     this.config = {
-      baseURL: "https://api.figma.com/v1",
+      baseURL: "https://api.figma.com",
       format: "svg",
       scale: 1,
       exportVariants: true,
@@ -73,10 +74,19 @@ export default class FigmaExporter {
    *
    * @private
    * @param {string} endpoint - API endpoint
+   * @param {Object} [params] - Query parameters
    * @returns {Promise<any>} Parsed JSON response
    */
-  async figmaGet(endpoint) {
-    const url = `${this.config.baseURL}${endpoint}`;
+  async figmaGet(endpoint, params = {}) {
+    const url = new URL(endpoint, this.config.baseURL);
+
+    // Add query parameters if any
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, value);
+      }
+    }
+
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -98,7 +108,10 @@ export default class FigmaExporter {
    * @returns {Promise<FigmaExporter>} The FigmaExporter instance.
    */
   async setAssets() {
-    const res = await this.figmaGet(`/files/${this.config.fileId}`);
+    const res = await this.figmaGet(`v1/files/${this.config.fileId}`, {
+      depth: this.config.depth,
+    });
+
     const page = res.document.children.find(
       (c) => c.name === this.config.page
     );
@@ -118,7 +131,7 @@ export default class FigmaExporter {
       assetsArray = frameRoot.children;
     }
 
-    let assets = assetsArray.flatMap((asset) => {
+    const assets = assetsArray.flatMap((asset) => {
       if (!this.config.exportVariants || !asset.children?.length) {
         return [
           {
@@ -164,9 +177,11 @@ export default class FigmaExporter {
       const batch = assets.slice(i, i + config.batchSize);
       const assetIds = batch.map((a) => a.id).join(",");
 
-      const res = await this.figmaGet(
-        `/images/${config.fileId}?ids=${assetIds}&format=${config.format}&scale=${config.scale}`
-      );
+      const res = await this.figmaGet(`v1/images/${config.fileId}`, {
+        ids: assetIds,
+        format: config.format,
+        scale: config.scale
+      });
 
       batch.forEach((asset) => {
         asset.url = res.images[asset.id];

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ import pLimit from "p-limit";
  * @property {boolean} [exportVariants=true] - Whether to export variants of the assets.
  * @property {string} [frame] - The name of the frame to export assets from.
  * @property {number} [depth] - Maximum number of nested levels to traverse in the Figma file.
- *   See [Figma API docs](https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint) 
- *   for more details.
+ * See [Figma API docs](https://developers.figma.com/docs/rest-api/file-endpoints/#get-files-endpoint) 
+ * for more details.
  * @property {number} [batchSize=100] - The number of assets to export in each batch.
  * @property {number} [concurrencyLimit=5] - The maximum number of concurrent requests.
  * @property {boolean} [skipExistingFiles=false] - Whether to skip existing files.


### PR DESCRIPTION
I'd like to propose a new optional configuration option that sets the max. number of nested levels to traverse in the Figma file. While I was at it, also refactored how `figmaGet()` handles query parameters.

`depth` is one of the params that the Figma API accepts:

> Positive integer representing how deep into the document tree to traverse. For example, setting this to 1 returns only Pages, setting it to 2 returns Pages and all top level objects on each page. Not setting this parameter returns all nodes.

https://www.figma.com/developers/api#get-files-endpoint

## Motivation
We're maintaining an icon library that provides each icon as a component positioned in a 24 × 24 grid (frame). All icon components are sitting on the top level of a page, without a frame around them.

Currently the export goes a bit too deep into the structure and exports the last node(s) it can find, e.g. individual `Vector` elements. Therefore the output SVGs come with `width="22" height="17" viewBox="0 0 22 17"` for example, instead of the desired `width="24" height="24" viewBox="0 0 24 24"`.

## Additional thoughts
I'm not 100% sure this is the _best_ solution and curious about other ideas.
* [`tsimenis/figma-export-icons`](https://github.com/tsimenis/figma-export-icons) supported this with `frame: -1`, but this does not feel very intuitive.
* Maybe `2` could even be the default setting when no specific frame is provided.